### PR TITLE
Remove unused content script and document permissions

### DIFF
--- a/GoogleScholarExtension Extension/Resources/content.js
+++ b/GoogleScholarExtension Extension/Resources/content.js
@@ -1,7 +1,0 @@
-browser.runtime.sendMessage({ greeting: "hello" }).then((response) => {
-    console.log("Received response: ", response);
-});
-
-browser.runtime.onMessage.addListener((request, sender, sendResponse) => {
-    console.log("Received request: ", request);
-});

--- a/GoogleScholarExtension Extension/Resources/manifest.json
+++ b/GoogleScholarExtension Extension/Resources/manifest.json
@@ -1,4 +1,6 @@
 {
+    // Manifest for Google Scholar Safari extension
+
     "manifest_version": 3,
     "default_locale": "en",
 
@@ -23,11 +25,14 @@
         "default_icon": "images/book-closed.svg"
     },
 
+    // activeTab allows reading current tab title
+    // nativeMessaging enables optional native integration
     "permissions": [
         "activeTab",
         "nativeMessaging"
     ],
 
+    // Permit background fetches to Google Scholar
     "host_permissions": [
         "https://scholar.google.com/*"
     ]


### PR DESCRIPTION
## Summary
- remove unused content script
- document host and tab permissions in manifest

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68959e50fea4832f9926e5fc61f05641