### PR TITLE
Add citation parser and unit tests for export formats

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "google-scholar-extension",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/tests/citationParser.test.js
+++ b/tests/citationParser.test.js
@@ -1,0 +1,24 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const { parseCitationHtml } = require('./utils/citationParser');
+
+test('parses citation information and export formats', () => {
+    const htmlPath = path.join(__dirname, 'fixtures', 'citation.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+    const { citations, exports } = parseCitationHtml(html);
+
+    // Ensure citation styles parsed
+    const apaCitation = citations.find(c => c.style === 'APA');
+    assert.ok(apaCitation, 'APA citation should exist');
+    assert.ok(
+        apaCitation.text.includes('Future Agriculture Farm Management using Augmented Reality'),
+        'APA citation should contain article title'
+    );
+
+    // Ensure export formats parsed
+    const formats = exports.map(e => e.format);
+    assert.ok(formats.includes('BibTeX'), 'BibTeX export should exist');
+    assert.ok(formats.includes('EndNote'), 'EndNote export should exist');
+});

--- a/tests/fixtures/citation.html
+++ b/tests/fixtures/citation.html
@@ -1,0 +1,20 @@
+<html>
+  <body>
+    <table id="gs_citt">
+      <tr>
+        <th>MLA</th>
+        <td>Doe, J., et al. "Future Agriculture Farm Management using Augmented Reality." Proceedings of the 2018 International Conference on Advanced Computer and Communication Systems. IEEE, 2018.</td>
+      </tr>
+      <tr>
+        <th>APA</th>
+        <td>Doe, J., Smith, A., & Roe, R. (2018). Future Agriculture Farm Management using Augmented Reality. In 2018 International Conference on Advanced Computer and Communication Systems.</td>
+      </tr>
+    </table>
+    <div id="gs_citi">
+      <a href="/scholar.bib?q=info:12345:scholar.google.com&output=citation&hl=en">BibTeX</a>
+      <a href="/scholar.enw?q=info:12345:scholar.google.com&output=citation&hl=en">EndNote</a>
+      <a href="/scholar.ris?q=info:12345:scholar.google.com&output=citation&hl=en">RefMan</a>
+      <a href="/scholar.rw?q=info:12345:scholar.google.com&output=citation&hl=en">RefWorks</a>
+    </div>
+  </body>
+</html>

--- a/tests/utils/citationParser.js
+++ b/tests/utils/citationParser.js
@@ -1,0 +1,43 @@
+// Test-only citation parser that mimics the citation extraction in popup.js.
+// It operates on raw HTML snippets returned by Google Scholar's citation dialog
+// so that unit tests can verify citation and export links without a DOM.
+
+function stripTags(str) {
+    return str.replace(/<[^>]*>/g, '');
+}
+
+function parseCitationHtml(html) {
+    const citations = [];
+    const citationTableMatch = html.match(/<table id="gs_citt">([\s\S]*?)<\/table>/i);
+    if (citationTableMatch) {
+        const rowsHtml = citationTableMatch[1];
+        const rowRegex = /<tr>\s*<th[^>]*>(.*?)<\/th>\s*<td[^>]*>(.*?)<\/td>\s*<\/tr>/gi;
+        let rowMatch;
+        while ((rowMatch = rowRegex.exec(rowsHtml)) !== null) {
+            const style = stripTags(rowMatch[1]).trim();
+            const text = stripTags(rowMatch[2]).trim();
+            if (style && text) {
+                citations.push({ style, text });
+            }
+        }
+    }
+
+    const exports = [];
+    const exportDivMatch = html.match(/<div id="gs_citi">([\s\S]*?)<\/div>/i);
+    if (exportDivMatch) {
+        const linksHtml = exportDivMatch[1];
+        const linkRegex = /<a[^>]*href="([^"]+)"[^>]*>(.*?)<\/a>/gi;
+        let linkMatch;
+        while ((linkMatch = linkRegex.exec(linksHtml)) !== null) {
+            const url = linkMatch[1];
+            const format = stripTags(linkMatch[2]).trim();
+            if (format) {
+                exports.push({ format, url });
+            }
+        }
+    }
+
+    return { citations, exports };
+}
+
+module.exports = { parseCitationHtml };


### PR DESCRIPTION
## Summary
- add simple citationParser to extract styles and export links from Google Scholar citation HTML
- create fixture based on "Future Agriculture Farm Management using Augmented Reality"
- add Node test verifying citation retrieval and BibTeX export handling
- move parser into test utils to clarify it mirrors popup.js citation extraction only for tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895a2d370ec832f886cb16a82c11a57