### PR TITLE
Refactor popup.js into single-file modular; Safari-only browser API; do cs and scheme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+
+# macOS metadata
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,15 @@ fastlane/test_output
 *.xcworkspace/xcuserdata/
 **/DerivedData/
 **/UserInterfaceState.xcuserstate
+
+
+# AI Agent Specific Files (Private/Local)
+# These files contain agent rules specific to each contributor
+# and should not be committed to the public repository.
+CLAUDE.md
+AGENT.md
+AGENTS.md
+GEMINI.md
+.cursorrules
+.windsurfrules
+.github/copilot-instructions.md

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,8 @@ fastlane/test_output
 
 # macOS metadata
 .DS_Store
+\n+# Additional Xcode noise
+*.xcodeproj/xcuserdata/
+*.xcworkspace/xcuserdata/
+**/DerivedData/
+**/UserInterfaceState.xcuserstate

--- a/GoogleScholarExtension Extension/Resources/popup.js
+++ b/GoogleScholarExtension Extension/Resources/popup.js
@@ -1,332 +1,293 @@
 /**
- * Main extension functionality for Google Scholar search
- * Handles search operations, result display, and citation management
+ * Popup script (single-file modular structure for Safari reliability)
+ * - Keeps logic in small sections (utils/services/scholar/dom/citations)
+ * - No ES module imports to avoid popup loading issues
  */
 
+// -- utils -------------------------------------------------------------------
+const Utils = (() => {
+  function cleanText(text = '') {
+    return String(text).replace(/\u00A0/g, ' ').replace(/\u0082/g, '').replace(/\s+/g, ' ').trim();
+  }
+  function extractNumber(text = '') {
+    const m = String(text).match(/\d+/);
+    return m ? Number(m[0]) : null;
+  }
+  function el(tag, opts = {}) {
+    const node = document.createElement(tag);
+    if (opts.className) node.className = opts.className;
+    if (opts.text !== undefined) node.textContent = opts.text;
+    if (opts.html !== undefined) node.innerHTML = opts.html;
+    if (opts.attrs) for (const [k, v] of Object.entries(opts.attrs)) node.setAttribute(k, v);
+    return node;
+  }
+  function absolutizeScholarUrl(href = '') {
+    if (!href) return '';
+    return href.startsWith('http') ? href : `https://scholar.google.com${href}`;
+  }
+  return { cleanText, extractNumber, el, absolutizeScholarUrl };
+})();
+
+// -- services ----------------------------------------------------------------
+const Services = (() => {
+  // Use Safari's browser API; fallback to chrome if present
+  const br = typeof browser !== 'undefined' ? browser : (typeof chrome !== 'undefined' ? chrome : undefined);
+
+  async function getActiveTabTitle() {
+    if (!br?.tabs?.query) return '';
+    const tabs = await br.tabs.query({ active: true, currentWindow: true });
+    return tabs?.[0]?.title || '';
+  }
+  async function fetchScholarHtml(query) {
+    const res = await br.runtime.sendMessage({ action: 'fetchScholar', query });
+    if (!res?.success) throw new Error(res?.error || 'Search failed');
+    return res.html;
+  }
+  async function fetchCitationsHtml(url) {
+    const res = await br.runtime.sendMessage({ action: 'fetchCitations', url });
+    if (!res?.success) throw new Error(res?.error || 'Citation fetch failed');
+    return res.html;
+  }
+  return { getActiveTabTitle, fetchScholarHtml, fetchCitationsHtml };
+})();
+
+// -- scholar (parse + helpers) ----------------------------------------------
+const Scholar = (() => {
+  const { cleanText, extractNumber, absolutizeScholarUrl } = Utils;
+
+  function buildCitationUrl(dataId) {
+    return `https://scholar.google.com/scholar?q=info:${dataId}:scholar.google.com/&output=cite&scirp=0&hl=en`;
+  }
+
+  function parseResults(html) {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, 'text/html');
+    const articles = Array.from(doc.querySelectorAll('.gs_r'));
+    const results = [];
+
+    for (const article of articles) {
+      if (article.classList.contains('gs_or_svg')) continue; // skip profiles
+
+      const titleEl = article.querySelector('.gs_rt a');
+      const authorsEl = article.querySelector('.gs_a');
+      const snippetEl = article.querySelector('.gs_rs');
+
+      const citedByLink = article.querySelector('a[href*="cites="]');
+      const relatedLink = article.querySelector('a[href*="q=related:"]');
+      const versionsLink = article.querySelector('a[href*="cluster="]');
+
+      const citeDataId = article.getAttribute('data-cid') || article.querySelector('[id^="gs_cit"]')?.getAttribute('data-cid') || undefined;
+
+      results.push({
+        title: titleEl ? cleanText(titleEl.textContent) : undefined,
+        url: titleEl ? absolutizeScholarUrl(titleEl.getAttribute('href') || '') : undefined,
+        authors: authorsEl ? cleanText(authorsEl.textContent) : undefined,
+        snippet: snippetEl ? cleanText(snippetEl.textContent) : undefined,
+        links: {
+          citeDataId,
+          citedBy: citedByLink ? { url: absolutizeScholarUrl(citedByLink.getAttribute('href') || ''), count: extractNumber(citedByLink.textContent || '') } : undefined,
+          related: relatedLink ? { url: absolutizeScholarUrl(relatedLink.getAttribute('href') || '') } : undefined,
+          versions: versionsLink ? { url: absolutizeScholarUrl(versionsLink.getAttribute('href') || ''), count: extractNumber(versionsLink.textContent || '') } : undefined,
+        },
+      });
+    }
+    return results;
+  }
+  return { parseResults, buildCitationUrl };
+})();
+
+// -- dom (render results) ----------------------------------------------------
+const Dom = (() => {
+  const { el } = Utils;
+
+  function renderResults(results, container, handlers = {}) {
+    for (const r of results) {
+      const item = el('div', { className: 'result-item' });
+
+      if (r.title && r.url) {
+        const a = el('a', { className: 'result-title', text: r.title });
+        a.setAttribute('href', r.url);
+        a.setAttribute('target', '_blank');
+        item.appendChild(a);
+      }
+      if (r.authors) item.appendChild(el('div', { className: 'result-authors', text: r.authors }));
+      if (r.snippet) item.appendChild(el('div', { className: 'result-snippet', text: r.snippet }));
+
+      const links = el('div', { className: 'result-links' });
+      const segs = [];
+
+      if (r.links?.citeDataId && handlers.onCite) {
+        const cite = el('a', { text: 'Cite' });
+        cite.setAttribute('href', '#');
+        cite.addEventListener('click', (e) => { e.preventDefault(); handlers.onCite(r.links.citeDataId); });
+        segs.push(cite);
+      }
+      if (r.links?.citedBy) {
+        const { url, count } = r.links.citedBy;
+        const cb = el('a', { text: count ? `Cited by ${count}` : 'Cited by' });
+        cb.setAttribute('href', url);
+        cb.setAttribute('target', '_blank');
+        segs.push(cb);
+      }
+      if (r.links?.related) {
+        const rel = el('a', { text: 'Related articles' });
+        rel.setAttribute('href', r.links.related.url);
+        rel.setAttribute('target', '_blank');
+        segs.push(rel);
+      }
+      if (r.links?.versions) {
+        const { url, count } = r.links.versions;
+        const v = el('a', { text: count ? `All ${count} versions` : 'All versions' });
+        v.setAttribute('href', url);
+        v.setAttribute('target', '_blank');
+        segs.push(v);
+      }
+
+      segs.forEach((node, i) => {
+        links.appendChild(node);
+        if (i < segs.length - 1) links.appendChild(el('span', { className: 'separator', html: ' &middot; ' }));
+      });
+
+      if (segs.length) item.appendChild(links);
+      container.appendChild(item);
+    }
+  }
+  return { renderResults };
+})();
+
+// -- citations (modal) -------------------------------------------------------
+const Citations = (() => {
+  function showCitationDialog(citationHtml) {
+    document.querySelector('.citation-overlay')?.remove();
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(citationHtml, 'text/html');
+
+    const overlay = document.createElement('div');
+    overlay.className = 'citation-overlay';
+    const dialog = document.createElement('div');
+    dialog.className = 'citation-dialog';
+
+    const title = document.createElement('div');
+    title.className = 'citation-title';
+    title.textContent = 'Citation Formats';
+    dialog.appendChild(title);
+
+    const closeButton = document.createElement('button');
+    closeButton.className = 'close-button';
+    closeButton.innerHTML = '×';
+    closeButton.addEventListener('click', () => overlay.remove());
+    dialog.appendChild(closeButton);
+
+    const table = document.createElement('table');
+    table.className = 'citation-table';
+
+    const citationTable = doc.querySelector('#gs_citt');
+    if (citationTable) {
+      const rows = citationTable.querySelectorAll('tr');
+      rows.forEach((row) => {
+        const tr = document.createElement('tr');
+        const style = document.createElement('td');
+        style.className = 'citation-style';
+        style.textContent = row.querySelector('th')?.textContent || '';
+        const text = document.createElement('td');
+        const citationText = row.querySelector('td')?.textContent || '';
+        text.className = 'citation-text clickable';
+        text.textContent = citationText;
+        text.addEventListener('click', async () => {
+          try {
+            await navigator.clipboard.writeText(citationText);
+            const original = text.textContent;
+            text.textContent = 'Copied!';
+            setTimeout(() => (text.textContent = original), 1000);
+          } catch {}
+        });
+        tr.appendChild(style);
+        tr.appendChild(text);
+        table.appendChild(tr);
+      });
+      table.appendChild(document.createElement('tr'));
+    } else {
+      table.innerHTML = '<tr><td colspan="2">No citations available</td></tr>';
+    }
+
+    const exportsSection = doc.querySelector('#gs_citi');
+    if (exportsSection) {
+      const exportLinks = exportsSection.querySelectorAll('a');
+      const exportRow = document.createElement('tr');
+      const exportCell = document.createElement('td');
+      exportCell.colSpan = 2;
+      exportLinks.forEach((link, i) => {
+        const a = document.createElement('a');
+        a.href = link.href;
+        a.textContent = link.textContent;
+        a.className = 'clickable';
+        a.target = '_blank';
+        exportCell.appendChild(a);
+        if (i < exportLinks.length - 1) exportCell.appendChild(document.createTextNode('\t'));
+      });
+      exportRow.appendChild(exportCell);
+      table.appendChild(exportRow);
+    }
+
+    dialog.appendChild(table);
+    overlay.appendChild(dialog);
+    document.body.appendChild(overlay);
+
+    overlay.addEventListener('click', (e) => { if (e.target === overlay) overlay.remove(); });
+  }
+  return { showCitationDialog };
+})();
+
+// -- bootstrap ---------------------------------------------------------------
 document.addEventListener('DOMContentLoaded', async () => {
-    const searchInput = document.getElementById('searchInput');
-    const searchButton = document.getElementById('searchButton');
-    const resultsDiv = document.getElementById('results');
+  const searchInput = document.getElementById('searchInput');
+  const searchButton = document.getElementById('searchButton');
+  const resultsDiv = document.getElementById('results');
 
-    // Get current tab's title when popup opens
-    const tab = await browser.tabs.query({ active: true, currentWindow: true });
-    searchInput.value = tab[0].title;
-
-    /**
-     * Cleans text content by removing special characters and extra whitespace
-     * @param {string} text - The text to clean
-     * @returns {string} Cleaned text
-     */
-    function cleanText(text) {
-        return text.replace(/\u00A0/g, ' ').replace(/\u0082/g, '').trim();
+  async function performSearch(query) {
+    if (!query) return;
+    resultsDiv.innerHTML = '<div class="loading">Searching...</div>';
+    try {
+      const html = await Services.fetchScholarHtml(query);
+      const results = Scholar.parseResults(html);
+      if (!results.length) {
+        resultsDiv.innerHTML = '<div class="result-item">No results found</div>';
+        return;
+      }
+      resultsDiv.innerHTML = '';
+      Dom.renderResults(results, resultsDiv, {
+        onCite: async (dataId) => {
+          try {
+            const url = Scholar.buildCitationUrl(dataId);
+            const citationHtml = await Services.fetchCitationsHtml(url);
+            Citations.showCitationDialog(citationHtml);
+          } catch (e) {
+            console.error('Failed to load citations', e);
+          }
+        },
+      });
+    } catch (error) {
+      resultsDiv.innerHTML = `
+        <div class="result-item">
+          Unable to fetch results directly.
+          <a href="https://scholar.google.com/scholar?q=${encodeURIComponent(query)}" target="_blank">
+            Click here to search on Google Scholar
+          </a>
+        </div>`;
     }
+  }
 
-    /**
-     * Extracts the first number from a text string
-     * Used for parsing citation and version counts
-     * @param {string} text - Text containing a number
-     * @returns {string|null} Extracted number or null if not found
-     */
-    function extractNumber(text) {
-        const match = text.match(/\d+/);
-        return match ? match[0] : null;
+  // Auto-seed with active tab title, as before
+  try {
+    const title = await Services.getActiveTabTitle();
+    if (title) {
+      searchInput.value = title;
+      performSearch(title);
     }
+  } catch {}
 
-    /**
-     * Fetches and displays citation information in a modal dialog
-     * @param {string} citationUrl - URL to fetch citations from
-     */
-    async function fetchCitations(citationUrl) {
-        try {
-            const response = await browser.runtime.sendMessage({
-                action: 'fetchCitations',
-                url: citationUrl
-            });
-
-            if (!response.success) throw new Error('Failed to fetch citations');
-
-            const parser = new DOMParser();
-            const doc = parser.parseFromString(response.html, 'text/html');
-            
-            // Remove any existing citation dialog
-            const existingDialog = document.querySelector('.citation-dialog');
-            if (existingDialog) {
-                existingDialog.remove();
-            }
-
-            // Create overlay
-            const overlay = document.createElement('div');
-            overlay.className = 'citation-overlay';
-            
-            // Create citation dialog
-            const dialog = document.createElement('div');
-            dialog.className = 'citation-dialog';
-            
-            // Add title
-            const title = document.createElement('div');
-            title.className = 'citation-title';
-            title.textContent = 'Citation Formats';
-            dialog.appendChild(title);
-            
-            // Add close button
-            const closeButton = document.createElement('button');
-            closeButton.className = 'close-button';
-            closeButton.innerHTML = '×';
-            dialog.appendChild(closeButton);
-
-            // Create citation table
-            const table = document.createElement('table');
-            table.className = 'citation-table';
-
-            // Try to find citation table in the response
-            const citationTable = doc.querySelector('#gs_citt');
-            if (citationTable) {
-                const rows = citationTable.querySelectorAll('tr');
-                rows.forEach(row => {
-                    const tr = document.createElement('tr');
-                    
-                    // Style (MLA, APA, etc.)
-                    const style = document.createElement('td');
-                    style.className = 'citation-style';
-                    style.textContent = row.querySelector('th')?.textContent || '';
-                    tr.appendChild(style);
-                    
-                    // Citation text - now clickable
-                    const text = document.createElement('td');
-                    text.className = 'citation-text clickable';
-                    const citationText = row.querySelector('td')?.textContent || '';
-                    text.textContent = citationText;
-                    text.onclick = () => {
-                        navigator.clipboard.writeText(citationText);
-                        
-                        // Show temporary "Copied!" feedback
-                        const originalText = text.textContent;
-                        text.textContent = 'Copied!';
-                        setTimeout(() => text.textContent = originalText, 1000);
-                    };
-                    
-                    tr.appendChild(text);
-                    table.appendChild(tr);
-                });
-                table.appendChild(document.createElement('tr'))
-            } else {
-                table.innerHTML = '<tr><td colspan="2">No citations available</td></tr>';
-            }
-                        
-            // Added Exports @dkillough Jul 24 2025
-            const citationExports = doc.querySelector('#gs_citi');
-            
-            if (citationExports) {
-                // Export options (BibTex, EndNote, RefMan, RefWorks)
-                const exportLinks = citationExports.querySelectorAll('a');
-                const exportRow = document.createElement('tr');
-                const exportCell = document.createElement('td');
-                exportCell.colSpan = 2; // span both columns of prior rows
-                
-                exportLinks.forEach((link, index) => {
-                    const exportOption = document.createElement('a');
-                    exportOption.href = link.href;
-                    exportOption.textContent = link.textContent;
-                    if(exportOption.href) {
-                        exportOption.className = 'clickable';  // since it's an anchor tag
-                        exportOption.target = '_blank';
-                    }
-                    exportCell.appendChild(exportOption);
-                    
-                    // insert a tab so the links aren't bunched up next to each other & clear styling
-                    if (index < exportLinks.length - 1) {
-                        exportCell.appendChild(document.createTextNode('\t'));
-                    }
-                })
-                exportRow.appendChild(exportCell);
-                table.appendChild(exportRow);
-            }
-            // (End changes Jul 24 2025)
-            
-            dialog.appendChild(table);
-            overlay.appendChild(dialog);
-            document.body.appendChild(overlay);
-
-            // Close handlers
-            const closeDialog = () => {
-                overlay.remove();
-            };
-
-            closeButton.onclick = closeDialog;
-            overlay.onclick = (e) => {
-                if (e.target === overlay) {
-                    closeDialog();
-                }
-            };
-
-        } catch (error) {
-            console.error('Error fetching citations:', error);
-        }
-    }
-
-    /**
-     * Performs a Google Scholar search and displays results
-     * @param {string} query - Search query
-     */
-    async function performSearch(query) {
-        resultsDiv.innerHTML = '<div class="loading">Searching...</div>';
-        
-        try {
-            const response = await browser.runtime.sendMessage({
-                action: 'fetchScholar',
-                query: query
-            });
-
-            if (!response.success) throw new Error('Search failed');
-            
-            const parser = new DOMParser();
-            const doc = parser.parseFromString(response.html, 'text/html');
-            const articles = doc.querySelectorAll('.gs_r');
-            
-            if (articles.length === 0) {
-                resultsDiv.innerHTML = '<div class="result-item">No results found</div>';
-                return;
-            }
-
-            resultsDiv.innerHTML = '';
-            articles.forEach(article => {
-                // Skip user profile results
-                if (article.classList.contains('gs_or_svg')) {
-                    return;
-                }
-
-                const titleElement = article.querySelector('.gs_rt a');
-                const authorsElement = article.querySelector('.gs_a');
-                const snippetElement = article.querySelector('.gs_rs');
-                const linksElement = article.querySelector('.gs_fl');
-
-                const resultItem = document.createElement('div');
-                resultItem.className = 'result-item';
-                
-                // Title
-                if (titleElement) {
-                    const title = document.createElement('a');
-                    const href = titleElement.getAttribute('href');
-                    title.href = href.startsWith('http') ? 
-                        href : 
-                        `https://scholar.google.com${href}`;
-                    title.className = 'result-title';
-                    title.textContent = cleanText(titleElement.textContent);
-                    title.target = '_blank';
-                    resultItem.appendChild(title);
-                }
-
-                // Authors and publication info
-                if (authorsElement) {
-                    const authors = document.createElement('div');
-                    authors.className = 'result-authors';
-                    authors.textContent = cleanText(authorsElement.textContent);
-                    resultItem.appendChild(authors);
-                }
-
-                // Abstract/snippet
-                if (snippetElement) {
-                    const snippet = document.createElement('div');
-                    snippet.className = 'result-snippet';
-                    snippet.textContent = cleanText(snippetElement.textContent);
-                    resultItem.appendChild(snippet);
-                }
-
-                // Additional links (cite, cited by, related articles, versions)
-                if (linksElement) {
-                    const links = document.createElement('div');
-                    links.className = 'result-links';
-                    
-                    const linkElements = [];
-
-                    // Updated Cite link selector and URL construction
-                    const citeButton = article.querySelector('.gs_or_cit');
-                    if (citeButton) {
-                        const dataId = article.getAttribute('data-cid') || 
-                                     article.querySelector('[id^="gs_cit"]')?.getAttribute('data-cid');
-                        if (dataId) {
-                            const cite = document.createElement('a');
-                            cite.href = '#';
-                            cite.textContent = 'Cite';
-                            cite.onclick = (e) => {
-                                e.preventDefault();
-                                const citationUrl = `https://scholar.google.com/scholar?q=info:${dataId}:scholar.google.com/&output=cite&scirp=0&hl=en`;
-                                fetchCitations(citationUrl);
-                            };
-                            linkElements.push(cite);
-                        }
-                    }
-
-                    // Cited by
-                    const citedByLink = article.querySelector('a[href*="cites="]');
-                    if (citedByLink) {
-                        const citedBy = document.createElement('a');
-                        citedBy.href = `https://scholar.google.com${citedByLink.getAttribute('href')}`;
-                        const citationCount = extractNumber(citedByLink.textContent);
-                        citedBy.textContent = citationCount ? `Cited by ${citationCount}` : 'Cited by';
-                        citedBy.target = '_blank';
-                        linkElements.push(citedBy);
-                    }
-
-                    // Related articles - updated selector
-                    const relatedLink = article.querySelector('a[href*="q=related:"]');
-                    if (relatedLink) {
-                        const related = document.createElement('a');
-                        related.href = `https://scholar.google.com${relatedLink.getAttribute('href')}`;
-                        related.textContent = 'Related articles';
-                        related.target = '_blank';
-                        linkElements.push(related);
-                    }
-
-                    // All versions
-                    const versionsLink = article.querySelector('a[href*="cluster="]');
-                    if (versionsLink) {
-                        const versions = document.createElement('a');
-                        versions.href = `https://scholar.google.com${versionsLink.getAttribute('href')}`;
-                        const versionCount = extractNumber(versionsLink.textContent);
-                        versions.textContent = versionCount ? `All ${versionCount} versions` : 'All versions';
-                        versions.target = '_blank';
-                        linkElements.push(versions);
-                    }
-
-                    // Add links with separators - using HTML entity for middot
-                    linkElements.forEach((link, index) => {
-                        links.appendChild(link);
-                        if (index < linkElements.length - 1) {
-                            const separator = document.createElement('span');
-                            separator.innerHTML = ' &middot; ';
-                            separator.className = 'separator';
-                            links.appendChild(separator);
-                        }
-                    });
-                    
-                    resultItem.appendChild(links);
-                }
-
-                resultsDiv.appendChild(resultItem);
-            });
-        } catch (error) {
-            resultsDiv.innerHTML = `
-                <div class="result-item">
-                    Unable to fetch results directly. 
-                    <a href="https://scholar.google.com/scholar?q=${encodeURIComponent(query)}" target="_blank">
-                        Click here to search on Google Scholar
-                    </a>
-                </div>`;
-        }
-    }
-
-    // Perform initial search with tab title
-    performSearch(tab[0].title);
-
-    // Event Listeners
-    searchButton.addEventListener('click', () => {
-        performSearch(searchInput.value);
-    });
-
-    searchInput.addEventListener('keypress', (e) => {
-        if (e.key === 'Enter') {
-            performSearch(searchInput.value);
-        }
-    });
+  // Event listeners (Search button and Enter key)
+  searchButton.addEventListener('click', () => performSearch(searchInput.value));
+  searchInput.addEventListener('keypress', (e) => { if (e.key === 'Enter') performSearch(searchInput.value); });
 });
+

--- a/GoogleScholarExtension Extension/Resources/popup.js
+++ b/GoogleScholarExtension Extension/Resources/popup.js
@@ -30,8 +30,8 @@ const Utils = (() => {
 
 // -- services ----------------------------------------------------------------
 const Services = (() => {
-  // Use Safari's browser API; fallback to chrome if present
-  const br = typeof browser !== 'undefined' ? browser : (typeof chrome !== 'undefined' ? chrome : undefined);
+  // Safari-only: use the WebExtension `browser` API directly
+  const br = browser;
 
   async function getActiveTabTitle() {
     if (!br?.tabs?.query) return '';
@@ -290,4 +290,3 @@ document.addEventListener('DOMContentLoaded', async () => {
   searchButton.addEventListener('click', () => performSearch(searchInput.value));
   searchInput.addEventListener('keypress', (e) => { if (e.key === 'Enter') performSearch(searchInput.value); });
 });
-

--- a/GoogleScholarExtension.xcodeproj/xcshareddata/xcschemes/GoogleScholarExtension.xcscheme
+++ b/GoogleScholarExtension.xcodeproj/xcshareddata/xcschemes/GoogleScholarExtension.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A27C1D502CD06220003D9794"
+               BuildableName = "GoogleScholarExtension.app"
+               BlueprintName = "GoogleScholarExtension"
+               ReferencedContainer = "container:GoogleScholarExtension.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A27C1D502CD06220003D9794"
+            BuildableName = "GoogleScholarExtension.app"
+            BlueprintName = "GoogleScholarExtension"
+            ReferencedContainer = "container:GoogleScholarExtension.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A27C1D502CD06220003D9794"
+            BuildableName = "GoogleScholarExtension.app"
+            BlueprintName = "GoogleScholarExtension"
+            ReferencedContainer = "container:GoogleScholarExtension.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ The extension consists of several key components:
 
 See `docs/ARCHITECTURE.md` for a deeper dive into code organization and data flow.
 
+### Browser Support
+
+- Safari on macOS only. The popup and background scripts use the WebExtension `browser` API exclusively; there is no `chrome` fallback.
+
 ### Key Features Implementation
 
 - **Search Processing**: Uses Google Scholar's search API with proper headers

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# GoogleScholarExtension
+# GoogleScholarExtension for Safari
 
 ## Project Overview
 
 GoogleScholarExtension is a Safari web extension that provides quick access to Google Scholar search results directly from your browser. The extension allows you to search academic papers based on the current tab's title or custom search terms, view citations, and interact with Google Scholar's features without leaving your browser.
+
+Current version: 1.0 (refactored popup to a reliable single-file modular script for Safari)
 
 ## Features
 
@@ -56,10 +58,17 @@ GoogleScholarExtension is a Safari web extension that provides quick access to G
 
 The extension consists of several key components:
 
-- **popup.html**: The main user interface
-- **popup.js**: Core functionality and search logic
-- **background.js**: Handles API requests to Google Scholar
-- **manifest.json**: Extension configuration and permissions
+- `popup.html`: Minimal shell that loads the popup script.
+- `popup.js`: Single-file modular script containing:
+  - Utils: text cleanup, number parsing, element helper, URL normalization
+  - Services: active tab title + background messaging for Scholar and citations
+  - Scholar: search HTML parsing + citation URL builder
+  - Dom: rendering and event wiring for results
+  - Citations: modal with copy-to-clipboard and export links
+- `background.js`: Performs cross-origin fetches to Scholar and citation pages with the correct headers.
+- `manifest.json`: Extension configuration and permissions.
+
+See `docs/ARCHITECTURE.md` for a deeper dive into code organization and data flow.
 
 ### Key Features Implementation
 
@@ -85,14 +94,29 @@ The extension consists of several key components:
 ### Project Structure
 
 ```
+docs/
+└── ARCHITECTURE.md     # Detailed architecture and flow
+
 GoogleScholarExtension Extension/
-├── Resources/
-│   ├── popup.html      # Main extension interface
-│   ├── popup.js        # Core extension logic
-│   ├── background.js   # Background processing
-│   ├── manifest.json   # Extension configuration
-│   └── images/         # Extension icons
+└── Resources/
+    ├── popup.html      # Main extension interface
+    ├── popup.js        # Single-file modular popup logic
+    ├── background.js   # Background processing (fetch)
+    ├── manifest.json   # Extension configuration
+    └── images/         # Extension icons
 ```
+
+### Documentation
+
+- Architecture overview: `docs/ARCHITECTURE.md`
+
+### Build
+
+Use the Xcode IDE:
+
+- Open `GoogleScholarExtension.xcodeproj` in Xcode
+- Select the "GoogleScholarExtension" scheme
+- Build and run; then enable the extension in Safari
 
 ## License
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,37 @@
+GoogleScholarExtension Popup Architecture
+
+Purpose
+- Developer-facing overview of the popup’s code organization and data flow to speed up onboarding and reviews.
+
+Version
+- Current popup design: single-file modular (IIFE sections) in `popup.js`.
+
+Last Updated
+- 2025-08-08
+
+Overview
+- The popup uses a single-file, modular structure (IIFE sections) for maximum reliability in Safari popups.
+- Logic is grouped by responsibility inside `popup.js` (utils, services, scholar, dom, citations) with clear boundaries and comments.
+
+Key Components
+- popup.html: Minimal shell that loads `popup.js` with a normal `<script>` tag.
+- popup.js: Contains logical modules:
+  - Utils: text cleanup, number parsing, DOM helpers, URL normalization
+  - Services: active tab title + background messaging for Scholar and citations
+  - Scholar: HTML parsing into a structured model + citation URL builder
+  - Dom: rendering the model to DOM with interactive handlers
+  - Citations: modal creation with copy-to-clipboard and export links
+- background.js: Performs cross-origin fetches to Scholar and citation pages.
+- manifest.json: Declares permissions and popup entry.
+
+Runtime Flow
+1) On load, Services.getActiveTabTitle seeds the search input and triggers a search.
+2) Services.fetchScholarHtml retrieves HTML; Scholar.parseResults converts it to a model.
+3) Dom.renderResults renders the list and wires link handlers.
+4) Cite → Scholar.buildCitationUrl → Services.fetchCitationsHtml → Citations.showCitationDialog.
+
+Notes
+- Single-file popup avoids module-loading edge cases in Safari popups while keeping code organized.
+- Background fetches centralize CORS-sensitive requests and user agent handling.
+- UI failures degrade gracefully to a direct Scholar link.
+

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,7 +7,7 @@ Version
 - Current popup design: single-file modular (IIFE sections) in `popup.js`.
 
 Last Updated
-- 2025-08-08
+- 2025-08-12
 
 Overview
 - The popup uses a single-file, modular structure (IIFE sections) for maximum reliability in Safari popups.
@@ -34,4 +34,4 @@ Notes
 - Single-file popup avoids module-loading edge cases in Safari popups while keeping code organized.
 - Background fetches centralize CORS-sensitive requests and user agent handling.
 - UI failures degrade gracefully to a direct Scholar link.
-
+- Safari-only API: Services uses the WebExtension `browser` API exclusively (no `chrome` fallback).


### PR DESCRIPTION

  - Modularize popup.js for Safari reliability (utils/services/scholar/dom/citat
ions).
  - Remove Chrome fallback; use `browser` API only.
  - Add architecture docs; clarify README; add shared Xcode scheme.
  - Tighten .gitignore (Xcode user data, local agent files).
