### PR TITLE
improve title extractor to use metadata instead of page title

### DIFF
--- a/GoogleScholarExtension Extension/Resources/manifest.json
+++ b/GoogleScholarExtension Extension/Resources/manifest.json
@@ -25,6 +25,7 @@
 
     "permissions": [
         "activeTab",
+        "scripting",
         "nativeMessaging"
     ],
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Current version: 1.0 (refactored popup to a reliable single-file modular script 
 ## Features
 
 - **Instant Search**: Automatically searches Google Scholar using the current tab's title
+- **Accurate Title Seeding**: Reads publisher metadata when available for precise paper titles
 - **Custom Search**: Allows manual search input for specific queries
 - **Rich Results**: Displays comprehensive search results including:
   - Paper titles with direct links
@@ -70,6 +71,18 @@ The extension consists of several key components:
 
 See `docs/ARCHITECTURE.md` for a deeper dive into code organization and data flow.
 
+### Title Extraction Logic
+
+When you open the popup, it seeds the search field using the active page's best-available title:
+
+- Priority:
+  1) `meta[name="citation_title"]`
+  2) `meta[name="dc.Title"]`, `meta[name="DC.title"]`, `meta[property="og:title"]`, `meta[name="twitter:title"]`, `meta[name="parsely-title"]`
+  3) Fallback to the tab title
+- Normalization removes common suffixes like `" | <site/venue>"`.
+
+This improves accuracy over relying on the generic tab title alone.
+
 ### Browser Support
 
 - Safari on macOS only. The popup and background scripts use the WebExtension `browser` API exclusively; there is no `chrome` fallback.
@@ -113,6 +126,14 @@ GoogleScholarExtension Extension/
 ### Documentation
 
 - Architecture overview: `docs/ARCHITECTURE.md`
+
+### Permissions
+
+The extension uses the following permissions:
+
+- `activeTab`: temporary access to the current page so the popup can read title metadata.
+- `scripting`: enables content script injection via the MV3 `browser.scripting` API for metadata extraction.
+- `host_permissions` for `https://scholar.google.com/*`: allows background fetches for search results and citations.
 
 ### Build
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -35,3 +35,18 @@ Notes
 - Background fetches centralize CORS-sensitive requests and user agent handling.
 - UI failures degrade gracefully to a direct Scholar link.
 - Safari-only API: Services uses the WebExtension `browser` API exclusively (no `chrome` fallback).
+
+Title Extraction (Active Tab → Initial Query)
+- Goal: seed the popup's search with the most accurate paper title from the active page.
+- Strategy: execute a small DOM query in the active tab and collect candidates in a fixed priority, with normalization.
+- Priority order for candidates:
+  1. `meta[name="citation_title"]` (Highwire/Google Scholar tags)
+  2. One of: `meta[name="dc.Title"]`, `meta[name="DC.title"]`, `meta[property="og:title"]`, `meta[name="twitter:title"]`, `meta[name="parsely-title"]`
+  3. Fallback: the browser tab’s title
+- Normalization: trim whitespace and strip common suffixes like `" | <site/venue>"` when present.
+- Injection: `Services.getActiveTabTitle` tries `browser.scripting.executeScript` first (MV3), and falls back to `tabs.executeScript` if needed. Failures silently degrade to the tab title.
+
+Permissions
+- `activeTab`: allows temporary access to the active page to read metadata when the user invokes the popup.
+- `scripting`: enables MV3 script injection via `browser.scripting.executeScript`.
+- `host_permissions`: `https://scholar.google.com/*` for background fetches of search and citations.


### PR DESCRIPTION
# Summary
- Improve initial query accuracy by extracting titles from common publisher meta tags in a fixed order, with normalisation and robust fallback. Update docs to reflect behaviour and add required permission.

# Why
- Relying on the tab title often yields noisy or truncated titles. Many publisher pages expose precise titles via metadata (e.g., Highwire, DC, OG). Using these first reduces manual edits and improves search relevance.

# What Changed
- **popup.js**
  - Implement fixed-priority extraction:
    1) `meta[name="citation_title"]`
    2) `meta[name="dc.Title"]`, `meta[name="DC.title"]`, `meta[property="og:title"]`, `meta[name="twitter:title"]`, `meta[name="parsely-title"]`
  - Normalise candidates (trim; strip trailing “ | …”).
  - Harden injector: try `browser.scripting.executeScript`, then `tabs.executeScript` if needed.
- **manifest.json**
  - Add `"scripting"` permission to enable MV3 injection.
- **Documentation**
  - `README.md`: new sections for Title Extraction Logic and Permissions.
  - `docs/ARCHITECTURE.md`: detailed flow for title extraction and permissions rationale.

# How It Works
- On popup open, inject a small script into the active tab to query candidates in priority order, normalise the first hit, and seed the search. If no candidates or errors, fall back to the tab title.

# Testing
- Build and run; enable the extension.
- Verify auto-seeded title on:
  - Highwire pages (expect exact `citation_title`).
  - OG/Twitter/Parsely pages (expect normalised meta title, e.g., “Title | Venue” → “Title”).
  - Pages without those metas (expect tab title).
- Confirm core flows still work:
  - Search results render with titles, authors, snippets.
  - “Cite” dialogue opens; copy works; export links open.

# Permissions
- `activeTab`: page access upon popup invocation.
- `scripting`: enables MV3 inject for metadata extraction.
- Host permissions unchanged (`https://scholar.google.com/*`).
